### PR TITLE
Overhead experiments

### DIFF
--- a/LKM/empty_scmap_with_struct_ops/Makefile
+++ b/LKM/empty_scmap_with_struct_ops/Makefile
@@ -1,4 +1,5 @@
 USE_CALLBACK_PARAM_COUNT ?= 5
+USE_CALLBACK_WORKAROUND ?= 1
 
 #KDIR ?= /home/chonepieceyb/CODING/Src/linux-6.0
 KDIR_DBG ?= /mnt/disk1/yangbin/CODING/WorkSpace/linux_testbed/linux
@@ -9,6 +10,7 @@ obj-m += empty_scmap_struct_ops.o
 obj-m += empty_primitive.o
 
 ccflags-y += -DUSE_CALLBACK_PARAM_COUNT=$(USE_CALLBACK_PARAM_COUNT)
+ccflags-y += -DUSE_CALLBACK_WORKAROUND=$(USE_CALLBACK_WORKAROUND)
 
 default:
 	bear -- make -C $(KDIR) M=$(PWD) modules

--- a/LKM/empty_scmap_with_struct_ops/Makefile
+++ b/LKM/empty_scmap_with_struct_ops/Makefile
@@ -1,0 +1,21 @@
+obj-m += empty_scmap_with_callback.o
+obj-m += empty_scmap_struct_ops.o
+
+#KDIR ?= /home/chonepieceyb/CODING/Src/linux-6.0
+KDIR_DBG ?= /mnt/disk1/yangbin/CODING/WorkSpace/linux_testbed/linux
+KDIR ?= /lib/modules/$(shell uname -r)/build
+
+default:
+	bear -- make -C $(KDIR) M=$(PWD) modules
+dbg:
+	bear -- make -C $(KDIR_DBG) M=$(PWD) modules
+clean:
+	make -C $(KDIR) M=$(PWD) clean
+test:j
+	-sudo rmmod $(OBJ_NAME)
+	sudo dmesg -C
+	sudo insmod $(OBJ_NAME).ko
+	sudo dmesg
+rm: 
+	-sudo rmmod $(OBJ_NAME)
+	sudo dmesg

--- a/LKM/empty_scmap_with_struct_ops/Makefile
+++ b/LKM/empty_scmap_with_struct_ops/Makefile
@@ -1,10 +1,14 @@
-obj-m += empty_scmap_with_callback.o
-obj-m += empty_scmap_struct_ops.o
-obj-m += empty_primitive.o
+USE_CALLBACK_PARAM_COUNT ?= 5
 
 #KDIR ?= /home/chonepieceyb/CODING/Src/linux-6.0
 KDIR_DBG ?= /mnt/disk1/yangbin/CODING/WorkSpace/linux_testbed/linux
 KDIR ?= /lib/modules/$(shell uname -r)/build
+
+obj-m += empty_scmap_with_callback.o
+obj-m += empty_scmap_struct_ops.o
+obj-m += empty_primitive.o
+
+ccflags-y += -DUSE_CALLBACK_PARAM_COUNT=$(USE_CALLBACK_PARAM_COUNT)
 
 default:
 	bear -- make -C $(KDIR) M=$(PWD) modules

--- a/LKM/empty_scmap_with_struct_ops/Makefile
+++ b/LKM/empty_scmap_with_struct_ops/Makefile
@@ -1,5 +1,6 @@
 obj-m += empty_scmap_with_callback.o
 obj-m += empty_scmap_struct_ops.o
+obj-m += empty_primitive.o
 
 #KDIR ?= /home/chonepieceyb/CODING/Src/linux-6.0
 KDIR_DBG ?= /mnt/disk1/yangbin/CODING/WorkSpace/linux_testbed/linux

--- a/LKM/empty_scmap_with_struct_ops/empty_primitive.c
+++ b/LKM/empty_scmap_with_struct_ops/empty_primitive.c
@@ -36,8 +36,9 @@ static const struct btf_kfunc_id_set empty_primitive_kfunc_set = {
 static int register_kfuncs(void)
 {
 	int ret;
-	if ((ret = register_btf_kfunc_id_set(
-		     BPF_PROG_TYPE_XDP, &empty_primitive_kfunc_set)) != 0) {
+	if ((ret = register_btf_kfunc_id_set(BPF_PROG_TYPE_STRUCT_OPS,
+					     &empty_primitive_kfunc_set)) !=
+	    0) {
 		return ret;
 	}
 

--- a/LKM/empty_scmap_with_struct_ops/empty_primitive.c
+++ b/LKM/empty_scmap_with_struct_ops/empty_primitive.c
@@ -3,11 +3,20 @@
 #include <linux/btf.h>
 #include <linux/btf_ids.h>
 
+#if USE_CALLBACK_PARAM_COUNT == 1
+__bpf_kfunc int empty_primitive(u64 param1)
+{
+	return 0;
+}
+#elif USE_CALLBACK_PARAM_COUNT == 5
 __bpf_kfunc int empty_primitive(u64 param1, u64 param2, u64 param3, u64 param4,
 				u64 param5)
 {
 	return 0;
 }
+#else
+#error "Unsupported USE_CALLBACK_PARAM_COUNT"
+#endif
 EXPORT_SYMBOL_GPL(empty_primitive);
 
 BTF_SET8_START(empty_primitive_kfunc_ids)

--- a/LKM/empty_scmap_with_struct_ops/empty_primitive.c
+++ b/LKM/empty_scmap_with_struct_ops/empty_primitive.c
@@ -1,0 +1,60 @@
+#include <linux/module.h>
+#include <linux/bpf.h>
+#include <linux/btf.h>
+#include <linux/btf_ids.h>
+
+__bpf_kfunc int empty_primitive(u64 param1, u64 param2, u64 param3, u64 param4,
+				u64 param5)
+{
+	return 0;
+}
+EXPORT_SYMBOL_GPL(empty_primitive);
+
+BTF_SET8_START(empty_primitive_kfunc_ids)
+BTF_ID_FLAGS(func, empty_primitive)
+BTF_SET8_END(empty_primitive_kfunc_ids)
+
+static const struct btf_kfunc_id_set empty_primitive_kfunc_set = {
+	.owner = THIS_MODULE,
+	.set = &empty_primitive_kfunc_ids,
+};
+
+static int register_kfuncs(void)
+{
+	int ret;
+	if ((ret = register_btf_kfunc_id_set(
+		     BPF_PROG_TYPE_XDP, &empty_primitive_kfunc_set)) != 0) {
+		return ret;
+	}
+
+	return 0;
+}
+
+static int __init empty_primitive_init(void)
+{
+	int ret;
+
+	if ((ret = register_kfuncs()) != 0) {
+		pr_err("empty_primitive: failed to register kfunc set: %d\n",
+		       ret);
+		return ret;
+	} else {
+		pr_info("empty_primitive: registered kfunc set\n");
+	}
+
+	pr_info("empty_primitive: initialized\n");
+	return 0;
+}
+
+static void __exit empty_primitive_exit(void)
+{
+	pr_info("empty_primitive: exiting\n");
+}
+
+module_init(empty_primitive_init);
+module_exit(empty_primitive_exit);
+
+MODULE_LICENSE("GPL");
+MODULE_AUTHOR("Yang Hanlin");
+MODULE_DESCRIPTION("An empty kfunc to call from BPF programs");
+MODULE_VERSION("0.0.1");

--- a/LKM/empty_scmap_with_struct_ops/empty_primitive.c
+++ b/LKM/empty_scmap_with_struct_ops/empty_primitive.c
@@ -3,7 +3,12 @@
 #include <linux/btf.h>
 #include <linux/btf_ids.h>
 
-#if USE_CALLBACK_PARAM_COUNT == 1
+#if USE_CALLBACK_PARAM_COUNT == 0
+__bpf_kfunc int empty_primitive(void)
+{
+	return 0;
+}
+#elif USE_CALLBACK_PARAM_COUNT == 1
 __bpf_kfunc int empty_primitive(u64 param1)
 {
 	return 0;

--- a/LKM/empty_scmap_with_struct_ops/empty_scmap_struct_ops.c
+++ b/LKM/empty_scmap_with_struct_ops/empty_scmap_struct_ops.c
@@ -14,8 +14,14 @@ bpf_unreg_module_struct_ops(struct bpf_module_struct_ops *mod_struct_ops);
 
 /* Same as `empty_scmap_callback_ops` */
 struct empty_scmap_struct_ops {
+#if USE_CALLBACK_PARAM_COUNT == 1
+	int (*callback)(u64 param1);
+#elif USE_CALLBACK_PARAM_COUNT == 5
 	int (*callback)(u64 param1, u64 param2, u64 param3, u64 param4,
 			u64 param5);
+#else
+#error "Unsupported USE_CALLBACK_PARAM_COUNT"
+#endif
 	struct module *owner;
 };
 

--- a/LKM/empty_scmap_with_struct_ops/empty_scmap_struct_ops.c
+++ b/LKM/empty_scmap_with_struct_ops/empty_scmap_struct_ops.c
@@ -1,0 +1,138 @@
+#include <linux/bpf_struct_ops_module.h>
+#include <linux/bpf.h>
+#include <linux/btf.h>
+#include <linux/bpf_verifier.h>
+
+#include "empty_scmap_with_callback.h"
+
+#define BPF_MOD_STRUCT_OPS_TYPES(fn) fn(empty_scmap_struct_ops)
+
+extern int
+bpf_reg_module_struct_ops(struct bpf_module_struct_ops *mod_struct_ops);
+extern int
+bpf_unreg_module_struct_ops(struct bpf_module_struct_ops *mod_struct_ops);
+
+/* Same as `empty_scmap_callback_ops` */
+struct empty_scmap_struct_ops {
+	int (*callback)(u64 param1, u64 param2, u64 param3, u64 param4,
+			u64 param5);
+	struct module *owner;
+};
+
+/*
+ * step3: implement struct bpf_struct_ops : 
+ * 1. init 
+ * 2. reg
+ * 3. unreg 
+ * 4. check_member
+ * 5. init_member 
+ * 6. set name to your module interface name, eg st_demo_ops here 
+ * 7. set verifier_ops
+ */
+
+static int empty_scmap_struct_ops_init(struct btf *btf)
+{
+	return 0;
+}
+
+static int empty_scmap_struct_ops_check_member(const struct btf_type *t,
+					       const struct btf_member *member,
+					       const struct bpf_prog *prog)
+{
+	u32 moff;
+	moff = __btf_member_bit_offset(t, member) / 8;
+	switch (moff) {
+	case offsetof(struct empty_scmap_struct_ops, callback):
+		/* allow to set first_func */
+		break;
+	default:
+		return -ENOTSUPP;
+	}
+	return 0;
+}
+
+static int empty_scmap_struct_ops_init_member(const struct btf_type *t,
+					      const struct btf_member *member,
+					      void *kdata, const void *udata)
+{
+	const struct empty_scmap_struct_ops *uop;
+	struct empty_scmap_struct_ops *op;
+	int prog_fd;
+	u32 moff;
+
+	uop = (const struct empty_scmap_struct_ops *)udata;
+	op = (struct empty_scmap_struct_ops *)kdata;
+
+	moff = __btf_member_bit_offset(t, member) / 8;
+
+	switch (moff) {
+	/*check function member */
+	case offsetof(struct empty_scmap_struct_ops, callback):
+		goto func_member;
+	default:
+		return -EINVAL;
+	}
+
+func_member:
+	prog_fd = (int)(*(unsigned long *)(udata + moff));
+	if (!prog_fd)
+		return -EINVAL;
+
+	return 0;
+}
+
+static int empty_scmap_struct_ops_reg(void *kdata)
+{
+	return empty_scmap_callback_register(
+		(struct empty_scmap_callback_ops *)kdata);
+}
+
+static void empty_scmap_struct_ops_unreg(void *kdata)
+{
+	empty_scmap_callback_unregister(
+		(struct empty_scmap_callback_ops *)kdata);
+}
+
+/* See $KERNEL/kernel/bpf/bpf_struct_ops.c */
+extern const struct bpf_verifier_ops default_mod_stops_verifier_ops;
+
+struct bpf_struct_ops bpf_empty_scmap_struct_ops = {
+	.verifier_ops = &default_mod_stops_verifier_ops,
+	.reg = empty_scmap_struct_ops_reg,
+	.unreg = empty_scmap_struct_ops_unreg,
+	.check_member = empty_scmap_struct_ops_check_member,
+	.init_member = empty_scmap_struct_ops_init_member,
+	.init = empty_scmap_struct_ops_init,
+	.name = "empty_scmap_struct_ops",
+};
+
+BPF_MODULE_STRUCT_OPS_SEC(empty_scmap_struct_ops, BPF_MOD_STRUCT_OPS_TYPES);
+
+static int __init empty_scmap_struct_ops_module_init(void)
+{
+	int ret;
+	ret = bpf_reg_module_struct_ops(empty_scmap_struct_ops);
+	if (ret < 0) {
+		pr_err("empty_scmap_struct_ops: failed to register mod_struct_ops %s\n",
+		       THIS_MODULE->name);
+		return -1;
+	}
+	pr_err("empty_scmap_struct_ops: register mod_struct_ops %s\n",
+	       THIS_MODULE->name);
+	return 0;
+}
+
+static void __exit empty_scmap_struct_ops_module_exit(void)
+{
+	bpf_unreg_module_struct_ops(empty_scmap_struct_ops);
+	pr_info("unregister mod_struct_ops %s\n", THIS_MODULE->name);
+}
+
+/* Register module functions */
+module_init(empty_scmap_struct_ops_module_init);
+module_exit(empty_scmap_struct_ops_module_exit);
+
+MODULE_LICENSE("GPL");
+MODULE_AUTHOR("Yang Hanlin");
+MODULE_DESCRIPTION("Empty scmap module struct ops");
+MODULE_VERSION("0.0.1");

--- a/LKM/empty_scmap_with_struct_ops/empty_scmap_struct_ops.c
+++ b/LKM/empty_scmap_with_struct_ops/empty_scmap_struct_ops.c
@@ -14,7 +14,9 @@ bpf_unreg_module_struct_ops(struct bpf_module_struct_ops *mod_struct_ops);
 
 /* Same as `empty_scmap_callback_ops` */
 struct empty_scmap_struct_ops {
-#if USE_CALLBACK_PARAM_COUNT == 1
+#if USE_CALLBACK_PARAM_COUNT == 0
+	int (*callback)(void);
+#elif USE_CALLBACK_PARAM_COUNT == 1
 	int (*callback)(u64 param1);
 #elif USE_CALLBACK_PARAM_COUNT == 5
 	int (*callback)(u64 param1, u64 param2, u64 param3, u64 param4,

--- a/LKM/empty_scmap_with_struct_ops/empty_scmap_struct_ops.c
+++ b/LKM/empty_scmap_with_struct_ops/empty_scmap_struct_ops.c
@@ -36,6 +36,10 @@ struct empty_scmap_struct_ops {
  * 7. set verifier_ops
  */
 
+#if USE_CALLBACK_WORKAROUND == 1
+static u32 callback_prog_fd = 0;
+#endif
+
 static int empty_scmap_struct_ops_init(struct btf *btf)
 {
 	return 0;
@@ -83,14 +87,26 @@ func_member:
 	prog_fd = (int)(*(unsigned long *)(udata + moff));
 	if (!prog_fd)
 		return -EINVAL;
+#if USE_CALLBACK_WORKAROUND == 1
+	else {
+		/* It works because the callback is the only function member for now */
+		pr_info("hash_mod_struct_ops: got callback fd %d\n", prog_fd);
+		callback_prog_fd = prog_fd;
+	}
+#endif
 
 	return 0;
 }
 
 static int empty_scmap_struct_ops_reg(void *kdata)
 {
+#if USE_CALLBACK_WORKAROUND == 1
+	return empty_scmap_callback_register(
+		(struct empty_scmap_callback_ops *)kdata, callback_prog_fd);
+#else
 	return empty_scmap_callback_register(
 		(struct empty_scmap_callback_ops *)kdata);
+#endif
 }
 
 static void empty_scmap_struct_ops_unreg(void *kdata)

--- a/LKM/empty_scmap_with_struct_ops/empty_scmap_with_callback.c
+++ b/LKM/empty_scmap_with_struct_ops/empty_scmap_with_callback.c
@@ -4,6 +4,7 @@
 #include <linux/string.h>
 #include <linux/math.h>
 #include <linux/bpf.h>
+#include <linux/filter.h>
 
 #include "empty_scmap_with_callback.h"
 
@@ -13,28 +14,63 @@ extern void bpf_unregister_static_cmap(struct module *onwer);
 extern void bpf_map_area_free(void *area);
 extern void *bpf_map_area_alloc(u64 size, int numa_node);
 
-struct empty_scmap_callback_ops *callback_ops;
-static DEFINE_SPINLOCK(callback_ops_lock);
-
+#if USE_CALLBACK_WORKAROUND == 1
+struct empty_scmap_callback_bpf_ctx {
 #if USE_CALLBACK_PARAM_COUNT == 1
-static int default_empty_scmap_callback(u64 param1)
-{
-	return 0;
-}
+	u64 param1;
 #elif USE_CALLBACK_PARAM_COUNT == 5
-static int default_empty_scmap_callback(u64 param1, u64 param2, u64 param3,
-					u64 param4, u64 param5)
-{
-	return 0;
-}
+	u64 param1;
+	u64 param2;
+	u64 param3;
+	u64 param4;
+	u64 param5;
 #else
 #error "Unsupported USE_CALLBACK_PARAM_COUNT"
 #endif
+};
+#endif
+
+struct empty_scmap_callback_ops *callback_ops;
+static DEFINE_SPINLOCK(callback_ops_lock);
+#if USE_CALLBACK_WORKAROUND == 1
+static struct bpf_prog *callback_prog = NULL;
+DEFINE_BPF_DISPATCHER(empty_scmap_callback)
+#endif
+
+#if USE_CALLBACK_PARAM_COUNT == 1
+static int default_empty_scmap_callback(u64 param1)
+#elif USE_CALLBACK_PARAM_COUNT == 5
+static int default_empty_scmap_callback(u64 param1, u64 param2, u64 param3,
+					u64 param4, u64 param5)
+#else
+#error "Unsupported USE_CALLBACK_PARAM_COUNT"
+#endif
+{
+	pr_warn("empty_scmap_with_callback: default callback called\n");
+	return 0;
+}
 DEFINE_STATIC_CALL_RET0(empty_scmap_callback, default_empty_scmap_callback);
 
+#if USE_CALLBACK_WORKAROUND == 1
+static inline void empty_scmap_callback_update(struct bpf_prog *prev_prog,
+					       struct bpf_prog *prog)
+{
+	bpf_dispatcher_change_prog(BPF_DISPATCHER_PTR(empty_scmap_callback),
+				   prev_prog, prog);
+}
+#endif
+
+#if USE_CALLBACK_WORKAROUND == 1
+int empty_scmap_callback_register(struct empty_scmap_callback_ops *ops,
+				  u32 prog_fd)
+#else
 int empty_scmap_callback_register(struct empty_scmap_callback_ops *ops)
+#endif
 {
 	int ret = 0;
+#if USE_CALLBACK_WORKAROUND == 1
+	struct bpf_prog *prog;
+#endif
 
 	if (!ops || !ops->callback || !ops->owner) {
 		pr_err("empty_scmap_with_callback: invalid ops or callback or owner\n");
@@ -54,7 +90,21 @@ int empty_scmap_callback_register(struct empty_scmap_callback_ops *ops)
 		ret = -ENODEV;
 		goto err_unlock;
 	}
+
+#if USE_CALLBACK_WORKAROUND == 1
+	prog = bpf_prog_get(prog_fd);
+	if (IS_ERR_OR_NULL(prog)) {
+		pr_err("empty_scmap_with_callback: failed to get BPF prog with fd %d\n",
+		       prog_fd);
+		ret = PTR_ERR(prog);
+		goto err_unlock;
+	}
+	empty_scmap_callback_update(callback_prog, prog);
+	callback_prog = prog;
+#else
 	static_call_update(empty_scmap_callback, ops->callback);
+#endif
+
 	callback_ops = ops;
 
 err_unlock:
@@ -74,7 +124,14 @@ void empty_scmap_callback_unregister(struct empty_scmap_callback_ops *ops)
 	spin_lock(&callback_ops_lock);
 
 	callback_ops = NULL;
+
+#if USE_CALLBACK_WORKAROUND == 1
+	empty_scmap_callback_update(callback_prog, NULL);
+	callback_prog = NULL;
+#else
 	static_call_update(empty_scmap_callback, default_empty_scmap_callback);
+#endif
+
 	bpf_module_put(ops, ops->owner);
 
 	spin_unlock(&callback_ops_lock);
@@ -110,6 +167,10 @@ static void *empty_cb_lookup_elem(struct bpf_map *map, void *key)
 {
 	u64 *args = (u64 *)key;
 
+#if USE_CALLBACK_WORKAROUND == 1
+	__bpf_prog_run(callback_prog, args,
+		       BPF_DISPATCHER_FUNC(empty_scmap_callback));
+#else
 #if USE_CALLBACK_PARAM_COUNT == 1
 	static_call(empty_scmap_callback)(args[0]);
 #elif USE_CALLBACK_PARAM_COUNT == 5
@@ -117,6 +178,7 @@ static void *empty_cb_lookup_elem(struct bpf_map *map, void *key)
 					  args[4]);
 #else
 #error "Unsupported USE_CALLBACK_PARAM_COUNT"
+#endif
 #endif
 
 	return NULL;

--- a/LKM/empty_scmap_with_struct_ops/empty_scmap_with_callback.c
+++ b/LKM/empty_scmap_with_struct_ops/empty_scmap_with_callback.c
@@ -81,7 +81,7 @@ int empty_scmap_callback_register(struct empty_scmap_callback_ops *ops)
 		goto err;
 	}
 
-	spin_lock(&callback_ops_lock);
+	// spin_lock(&callback_ops_lock);
 
 	if (callback_ops) {
 		pr_err("empty_scmap_with_callback: callback already registered\n");
@@ -102,6 +102,7 @@ int empty_scmap_callback_register(struct empty_scmap_callback_ops *ops)
 		ret = PTR_ERR(prog);
 		goto err_unlock;
 	}
+	bpf_prog_put(prog);
 	empty_scmap_callback_update(callback_prog, prog);
 	callback_prog = prog;
 #else
@@ -111,7 +112,7 @@ int empty_scmap_callback_register(struct empty_scmap_callback_ops *ops)
 	callback_ops = ops;
 
 err_unlock:
-	spin_unlock(&callback_ops_lock);
+	// spin_unlock(&callback_ops_lock);
 err:
 	return ret;
 }
@@ -124,7 +125,7 @@ void empty_scmap_callback_unregister(struct empty_scmap_callback_ops *ops)
 		return;
 	}
 
-	spin_lock(&callback_ops_lock);
+	// spin_lock(&callback_ops_lock);
 
 	callback_ops = NULL;
 
@@ -137,7 +138,7 @@ void empty_scmap_callback_unregister(struct empty_scmap_callback_ops *ops)
 
 	bpf_module_put(ops, ops->owner);
 
-	spin_unlock(&callback_ops_lock);
+	// spin_unlock(&callback_ops_lock);
 }
 EXPORT_SYMBOL_GPL(empty_scmap_callback_unregister);
 

--- a/LKM/empty_scmap_with_struct_ops/empty_scmap_with_callback.c
+++ b/LKM/empty_scmap_with_struct_ops/empty_scmap_with_callback.c
@@ -16,7 +16,8 @@ extern void *bpf_map_area_alloc(u64 size, int numa_node);
 
 #if USE_CALLBACK_WORKAROUND == 1
 struct empty_scmap_callback_bpf_ctx {
-#if USE_CALLBACK_PARAM_COUNT == 1
+#if USE_CALLBACK_PARAM_COUNT == 0
+#elif USE_CALLBACK_PARAM_COUNT == 1
 	u64 param1;
 #elif USE_CALLBACK_PARAM_COUNT == 5
 	u64 param1;
@@ -37,11 +38,13 @@ static struct bpf_prog *callback_prog = NULL;
 DEFINE_BPF_DISPATCHER(empty_scmap_callback)
 #endif
 
-#if USE_CALLBACK_PARAM_COUNT == 1
-static int default_empty_scmap_callback(u64 param1)
+#if USE_CALLBACK_PARAM_COUNT == 0
+int default_empty_scmap_callback(void)
+#elif USE_CALLBACK_PARAM_COUNT == 1
+int default_empty_scmap_callback(u64 param1)
 #elif USE_CALLBACK_PARAM_COUNT == 5
-static int default_empty_scmap_callback(u64 param1, u64 param2, u64 param3,
-					u64 param4, u64 param5)
+int default_empty_scmap_callback(u64 param1, u64 param2, u64 param3, u64 param4,
+				 u64 param5)
 #else
 #error "Unsupported USE_CALLBACK_PARAM_COUNT"
 #endif
@@ -144,6 +147,14 @@ struct static_empty_cb_map {
 
 int empty_cb_alloc_check(union bpf_attr *attr)
 {
+	/* Allow any key size of expected "key size" is 0 */
+	if (USE_CALLBACK_PARAM_COUNT > 0 &&
+	    attr->key_size != sizeof(u64) * USE_CALLBACK_PARAM_COUNT) {
+		pr_err("empty_scmap_with_callback: invalid key_size %u\n",
+		       attr->key_size);
+		return -EINVAL;
+	}
+
 	return 0;
 }
 
@@ -171,7 +182,9 @@ static void *empty_cb_lookup_elem(struct bpf_map *map, void *key)
 	__bpf_prog_run(callback_prog, args,
 		       BPF_DISPATCHER_FUNC(empty_scmap_callback));
 #else
-#if USE_CALLBACK_PARAM_COUNT == 1
+#if USE_CALLBACK_PARAM_COUNT == 0
+	static_call(empty_scmap_callback)();
+#elif USE_CALLBACK_PARAM_COUNT == 1
 	static_call(empty_scmap_callback)(args[0]);
 #elif USE_CALLBACK_PARAM_COUNT == 5
 	static_call(empty_scmap_callback)(args[0], args[1], args[2], args[3],

--- a/LKM/empty_scmap_with_struct_ops/empty_scmap_with_callback.c
+++ b/LKM/empty_scmap_with_struct_ops/empty_scmap_with_callback.c
@@ -32,7 +32,7 @@ struct empty_scmap_callback_bpf_ctx {
 #endif
 
 struct empty_scmap_callback_ops *callback_ops;
-static DEFINE_SPINLOCK(callback_ops_lock);
+// static DEFINE_SPINLOCK(callback_ops_lock);
 #if USE_CALLBACK_WORKAROUND == 1
 static struct bpf_prog *callback_prog = NULL;
 DEFINE_BPF_DISPATCHER(empty_scmap_callback)

--- a/LKM/empty_scmap_with_struct_ops/empty_scmap_with_callback.c
+++ b/LKM/empty_scmap_with_struct_ops/empty_scmap_with_callback.c
@@ -16,11 +16,20 @@ extern void *bpf_map_area_alloc(u64 size, int numa_node);
 struct empty_scmap_callback_ops *callback_ops;
 static DEFINE_SPINLOCK(callback_ops_lock);
 
+#if USE_CALLBACK_PARAM_COUNT == 1
+static int default_empty_scmap_callback(u64 param1)
+{
+	return 0;
+}
+#elif USE_CALLBACK_PARAM_COUNT == 5
 static int default_empty_scmap_callback(u64 param1, u64 param2, u64 param3,
 					u64 param4, u64 param5)
 {
 	return 0;
 }
+#else
+#error "Unsupported USE_CALLBACK_PARAM_COUNT"
+#endif
 DEFINE_STATIC_CALL_RET0(empty_scmap_callback, default_empty_scmap_callback);
 
 int empty_scmap_callback_register(struct empty_scmap_callback_ops *ops)
@@ -101,8 +110,14 @@ static void *empty_cb_lookup_elem(struct bpf_map *map, void *key)
 {
 	u64 *args = (u64 *)key;
 
+#if USE_CALLBACK_PARAM_COUNT == 1
+	static_call(empty_scmap_callback)(args[0]);
+#elif USE_CALLBACK_PARAM_COUNT == 5
 	static_call(empty_scmap_callback)(args[0], args[1], args[2], args[3],
 					  args[4]);
+#else
+#error "Unsupported USE_CALLBACK_PARAM_COUNT"
+#endif
 
 	return NULL;
 }

--- a/LKM/empty_scmap_with_struct_ops/empty_scmap_with_callback.c
+++ b/LKM/empty_scmap_with_struct_ops/empty_scmap_with_callback.c
@@ -1,0 +1,153 @@
+#include <linux/static_call.h>
+#include <linux/init.h>
+#include <linux/printk.h>
+#include <linux/string.h>
+#include <linux/math.h>
+#include <linux/bpf.h>
+
+#include "empty_scmap_with_callback.h"
+
+extern int bpf_register_static_cmap(struct bpf_map_ops *map,
+				    struct module *onwer);
+extern void bpf_unregister_static_cmap(struct module *onwer);
+extern void bpf_map_area_free(void *area);
+extern void *bpf_map_area_alloc(u64 size, int numa_node);
+
+struct empty_scmap_callback_ops *callback_ops;
+static DEFINE_SPINLOCK(callback_ops_lock);
+
+static int default_empty_scmap_callback(u64 param1, u64 param2, u64 param3,
+					u64 param4, u64 param5)
+{
+	return 0;
+}
+DEFINE_STATIC_CALL_RET0(empty_scmap_callback, default_empty_scmap_callback);
+
+int empty_scmap_callback_register(struct empty_scmap_callback_ops *ops)
+{
+	int ret = 0;
+
+	if (!ops || !ops->callback || !ops->owner) {
+		pr_err("empty_scmap_with_callback: invalid ops or callback or owner\n");
+		ret = -EINVAL;
+		goto err;
+	}
+
+	spin_lock(&callback_ops_lock);
+
+	if (callback_ops) {
+		pr_err("empty_scmap_with_callback: callback already registered\n");
+		ret = -EEXIST;
+		goto err_unlock;
+	}
+	if (!bpf_try_module_get(ops, ops->owner)) {
+		pr_err("empty_scmap_with_callback: failed to get BPF module\n");
+		ret = -ENODEV;
+		goto err_unlock;
+	}
+	static_call_update(empty_scmap_callback, ops->callback);
+	callback_ops = ops;
+
+err_unlock:
+	spin_unlock(&callback_ops_lock);
+err:
+	return ret;
+}
+EXPORT_SYMBOL_GPL(empty_scmap_callback_register);
+
+void empty_scmap_callback_unregister(struct empty_scmap_callback_ops *ops)
+{
+	if (!ops || !ops->owner) {
+		pr_warn("empty_scmap_with_callback: invalid ops or owner; ignoring\n");
+		return;
+	}
+
+	spin_lock(&callback_ops_lock);
+
+	callback_ops = NULL;
+	static_call_update(empty_scmap_callback, default_empty_scmap_callback);
+	bpf_module_put(ops, ops->owner);
+
+	spin_unlock(&callback_ops_lock);
+}
+EXPORT_SYMBOL_GPL(empty_scmap_callback_unregister);
+
+struct static_empty_cb_map {
+	struct bpf_map map;
+};
+
+int empty_cb_alloc_check(union bpf_attr *attr)
+{
+	return 0;
+}
+
+static struct bpf_map *empty_cb_alloc(union bpf_attr *attr)
+{
+	struct static_empty_cb_map *map;
+	map = bpf_map_area_alloc(sizeof(struct static_empty_cb_map),
+				 NUMA_NO_NODE);
+	if (map == NULL) {
+		return ERR_PTR(-ENOMEM);
+	}
+	return (struct bpf_map *)map;
+}
+
+static void empty_cb_free(struct bpf_map *map)
+{
+	bpf_map_area_free(map);
+}
+
+static void *empty_cb_lookup_elem(struct bpf_map *map, void *key)
+{
+	u64 *args = (u64 *)key;
+
+	static_call(empty_scmap_callback)(args[0], args[1], args[2], args[3],
+					  args[4]);
+
+	return NULL;
+}
+
+static long empty_cb_update_elem(struct bpf_map *map, void *key, void *value,
+				 u64 flags)
+{
+	return 0;
+}
+
+static long empty_cb_delete_elem(struct bpf_map *map, void *key)
+{
+	return 0;
+}
+
+static u64 empty_cb_mem_usage(const struct bpf_map *map)
+{
+	return 0;
+}
+
+static struct bpf_map_ops empty_cb_ops = {
+	.map_alloc = empty_cb_alloc,
+	.map_free = empty_cb_free,
+	.map_lookup_elem = empty_cb_lookup_elem,
+	.map_update_elem = empty_cb_update_elem,
+	.map_delete_elem = empty_cb_delete_elem,
+	.map_mem_usage = empty_cb_mem_usage
+};
+
+static int __init empty_cmaps_with_callback_init(void)
+{
+	pr_info("register static empty_scmap_with_callback");
+	return bpf_register_static_cmap(&empty_cb_ops, THIS_MODULE);
+}
+
+static void __exit empty_cmaps_with_callback_exit(void)
+{
+	pr_info("unregister static empty_scmap_with_callback");
+	bpf_unregister_static_cmap(THIS_MODULE);
+}
+
+module_init(empty_cmaps_with_callback_init);
+module_exit(empty_cmaps_with_callback_exit);
+
+MODULE_LICENSE("GPL");
+MODULE_AUTHOR("chonepieceyb");
+MODULE_DESCRIPTION("An empty scmap with lookup callback");
+MODULE_VERSION("0.0.1");

--- a/LKM/empty_scmap_with_struct_ops/empty_scmap_with_callback.h
+++ b/LKM/empty_scmap_with_struct_ops/empty_scmap_with_callback.h
@@ -1,8 +1,14 @@
 #include <linux/module.h>
 
 struct empty_scmap_callback_ops {
+#if USE_CALLBACK_PARAM_COUNT == 1
+	int (*callback)(u64 param1);
+#elif USE_CALLBACK_PARAM_COUNT == 5
 	int (*callback)(u64 param1, u64 param2, u64 param3, u64 param4,
 			u64 param5);
+#else
+#error "Unsupported USE_CALLBACK_PARAM_COUNT"
+#endif
 	struct module *owner;
 };
 

--- a/LKM/empty_scmap_with_struct_ops/empty_scmap_with_callback.h
+++ b/LKM/empty_scmap_with_struct_ops/empty_scmap_with_callback.h
@@ -12,7 +12,12 @@ struct empty_scmap_callback_ops {
 	struct module *owner;
 };
 
+#if USE_CALLBACK_WORKAROUND == 1
+extern int empty_scmap_callback_register(struct empty_scmap_callback_ops *ops,
+					 u32 prog_fd);
+#else
 extern int empty_scmap_callback_register(struct empty_scmap_callback_ops *ops);
+#endif
 
 extern void
 empty_scmap_callback_unregister(struct empty_scmap_callback_ops *ops);

--- a/LKM/empty_scmap_with_struct_ops/empty_scmap_with_callback.h
+++ b/LKM/empty_scmap_with_struct_ops/empty_scmap_with_callback.h
@@ -1,0 +1,12 @@
+#include <linux/module.h>
+
+struct empty_scmap_callback_ops {
+	int (*callback)(u64 param1, u64 param2, u64 param3, u64 param4,
+			u64 param5);
+	struct module *owner;
+};
+
+extern int empty_scmap_callback_register(struct empty_scmap_callback_ops *ops);
+
+extern void
+empty_scmap_callback_unregister(struct empty_scmap_callback_ops *ops);

--- a/LKM/empty_scmap_with_struct_ops/empty_scmap_with_callback.h
+++ b/LKM/empty_scmap_with_struct_ops/empty_scmap_with_callback.h
@@ -1,7 +1,9 @@
 #include <linux/module.h>
 
 struct empty_scmap_callback_ops {
-#if USE_CALLBACK_PARAM_COUNT == 1
+#if USE_CALLBACK_PARAM_COUNT == 0
+	int (*callback)(void);
+#elif USE_CALLBACK_PARAM_COUNT == 1
 	int (*callback)(u64 param1);
 #elif USE_CALLBACK_PARAM_COUNT == 5
 	int (*callback)(u64 param1, u64 param2, u64 param3, u64 param4,

--- a/src/bpf_kern/cmaps/scmap_empty_cb_base.c
+++ b/src/bpf_kern/cmaps/scmap_empty_cb_base.c
@@ -1,0 +1,36 @@
+#include "../common.h"
+
+#define STATIC_MAX(a, b) ((a) > (b) ? (a) : (b))
+
+#define USE_CALLBACK_PARAM_COUNT 5
+
+char _license[] SEC("license") = "GPL";
+
+typedef u64 scmap_empty_cb_key_type[STATIC_MAX(USE_CALLBACK_PARAM_COUNT, 1)];
+
+struct {
+	__uint(type, BPF_MAP_TYPE_STATIC_CUSTOM_MAP);
+	__type(key, scmap_empty_cb_key_type);
+	__type(value, int);
+	__uint(max_entries, 1);
+} scmap_empty_cb SEC(".maps");
+
+SEC("xdp")
+int xdp_main(struct xdp_md *ctx)
+{
+	scmap_empty_cb_key_type key = {
+#if USE_CALLBACK_PARAM_COUNT == 0 || USE_CALLBACK_PARAM_COUNT == 1
+		1,
+#elif USE_CALLBACK_PARAM_COUNT == 5
+		1,
+		2,
+		3,
+		4,
+		5,
+#else
+#error "Unsupported USE_CALLBACK_PARAM_COUNT"
+#endif
+	};
+	bpf_map_lookup_elem(&scmap_empty_cb, &key);
+	return XDP_DROP;
+}

--- a/src/bpf_kern/cmaps/scmap_empty_cb_ext.c
+++ b/src/bpf_kern/cmaps/scmap_empty_cb_ext.c
@@ -1,0 +1,49 @@
+#include "../common.h"
+
+#include <bpf/bpf_tracing.h>
+
+#define USE_CALLBACK_PARAM_COUNT 5
+
+struct empty_scmap_struct_ops {
+#if USE_CALLBACK_PARAM_COUNT == 0
+	int (*callback)(void);
+#elif USE_CALLBACK_PARAM_COUNT == 1
+	int (*callback)(u64 param1);
+#elif USE_CALLBACK_PARAM_COUNT == 5
+	int (*callback)(u64 param1, u64 param2, u64 param3, u64 param4,
+			u64 param5);
+#else
+#error "Unsupported USE_CALLBACK_PARAM_COUNT"
+#endif
+	struct module *owner;
+};
+
+char _license[] SEC("license") = "GPL";
+
+#if USE_CALLBACK_PARAM_COUNT == 0
+SEC("struct_ops/empty_scmap_callback")
+int BPF_PROG(empty_cb_callback)
+{
+	return 0;
+}
+#elif USE_CALLBACK_PARAM_COUNT == 1
+SEC("struct_ops/empty_scmap_callback")
+int BPF_PROG(empty_cb_callback, u64 param1)
+{
+	return param1;
+}
+#elif USE_CALLBACK_PARAM_COUNT == 5
+SEC("struct_ops/empty_scmap_callback")
+int BPF_PROG(empty_cb_callback, u64 param1, u64 param2, u64 param3, u64 param4,
+	     u64 param5)
+{
+	return param1 ^ param2 ^ param3 ^ param4 ^ param5;
+}
+#else
+#error "Unsupported USE_CALLBACK_PARAM_COUNT"
+#endif
+
+SEC(".struct_ops")
+struct empty_scmap_struct_ops empty_cb_ops = {
+	.callback = (void *)empty_cb_callback,
+};

--- a/src/bpf_kern/cmaps/scmap_empty_cb_ext_primitive.c
+++ b/src/bpf_kern/cmaps/scmap_empty_cb_ext_primitive.c
@@ -1,0 +1,60 @@
+#include "../common.h"
+
+#include <bpf/bpf_tracing.h>
+
+#define USE_CALLBACK_PARAM_COUNT 5
+
+#if USE_CALLBACK_PARAM_COUNT == 0
+extern int empty_primitive(void) __ksym;
+#elif USE_CALLBACK_PARAM_COUNT == 1
+extern int empty_primitive(u64 param1) __ksym;
+#elif USE_CALLBACK_PARAM_COUNT == 5
+extern int empty_primitive(u64 param1, u64 param2, u64 param3, u64 param4,
+			   u64 param5) __ksym;
+#else
+#error "Unsupported USE_CALLBACK_PARAM_COUNT"
+#endif
+
+struct empty_scmap_struct_ops {
+#if USE_CALLBACK_PARAM_COUNT == 0
+	int (*callback)(void);
+#elif USE_CALLBACK_PARAM_COUNT == 1
+	int (*callback)(u64 param1);
+#elif USE_CALLBACK_PARAM_COUNT == 5
+	int (*callback)(u64 param1, u64 param2, u64 param3, u64 param4,
+			u64 param5);
+#else
+#error "Unsupported USE_CALLBACK_PARAM_COUNT"
+#endif
+	struct module *owner;
+};
+
+char _license[] SEC("license") = "GPL";
+
+#if USE_CALLBACK_PARAM_COUNT == 0
+SEC("struct_ops/empty_scmap_callback")
+int BPF_PROG(empty_cb_callback)
+{
+	return empty_primitive();
+}
+#elif USE_CALLBACK_PARAM_COUNT == 1
+SEC("struct_ops/empty_scmap_callback")
+int BPF_PROG(empty_cb_callback, u64 param1)
+{
+	return empty_primitive(param1);
+}
+#elif USE_CALLBACK_PARAM_COUNT == 5
+SEC("struct_ops/empty_scmap_callback")
+int BPF_PROG(empty_cb_callback, u64 param1, u64 param2, u64 param3, u64 param4,
+	     u64 param5)
+{
+	return empty_primitive(param1, param2, param3, param4, param5);
+}
+#else
+#error "Unsupported USE_CALLBACK_PARAM_COUNT"
+#endif
+
+SEC(".struct_ops")
+struct empty_scmap_struct_ops empty_cb_ops = {
+	.callback = (void *)empty_cb_callback,
+};

--- a/src/bpf_kern/cmaps/scmap_empty_lookup.c
+++ b/src/bpf_kern/cmaps/scmap_empty_lookup.c
@@ -1,0 +1,35 @@
+#include "../common.h"
+
+char _license[] SEC("license") = "GPL";
+
+struct cmap_key_type {
+	int key;
+};
+
+struct cmap_value_type {
+	int data;
+};
+
+struct {
+	__uint(type, BPF_MAP_TYPE_STATIC_CUSTOM_MAP);
+	__type(key, struct cmap_key_type);
+	__type(value, int);
+	__uint(max_entries, 1);
+} cmap SEC(".maps");
+
+SEC("xdp")
+int xdp_main(struct xdp_md *ctx)
+{
+	struct cmap_value_type *val;
+	struct cmap_key_type key = { .key = 0 };
+	struct cmap_value_type value = { .data = 0 };
+
+	val = bpf_map_lookup_elem(&cmap, &key);
+	if (val == NULL) {
+		log_error("failed to lookup scmap");
+		return XDP_DROP;
+	}
+
+	log_info("get res %d", val->data);
+	return XDP_DROP;
+}

--- a/src/bpf_kern/cmaps/scmap_empty_update.c
+++ b/src/bpf_kern/cmaps/scmap_empty_update.c
@@ -1,0 +1,33 @@
+#include "../common.h"
+
+char _license[] SEC("license") = "GPL";
+
+struct cmap_key_type {
+	int key;
+};
+
+struct cmap_value_type {
+	int data;
+};
+
+struct {
+	__uint(type, BPF_MAP_TYPE_STATIC_CUSTOM_MAP);
+	__type(key, struct cmap_key_type);
+	__type(value, int);
+	__uint(max_entries, 1);
+} cmap SEC(".maps");
+
+SEC("xdp")
+int xdp_main(struct xdp_md *ctx)
+{
+	int res;
+	struct cmap_key_type key = { .key = 0 };
+	struct cmap_value_type value = { .data = 0 };
+
+	if ((res = bpf_map_update_elem(&cmap, &key, &value, BPF_ANY))) {
+		log_error("failed to update cmap: %d", res);
+		return XDP_DROP;
+	}
+
+	return XDP_DROP;
+}

--- a/src/c/cmaps/scmap_empty_cb_primitive_user.c
+++ b/src/c/cmaps/scmap_empty_cb_primitive_user.c
@@ -1,0 +1,27 @@
+#include "../common.h"
+#include "../bpf_skel/scmap_empty_cb_base.skel.h"
+#include "../bpf_skel/scmap_empty_cb_ext_primitive.skel.h"
+#include "../test_helpers.h"
+
+#define XDP_IF "ens2f0"
+
+struct scmap_empty_cb_ext_primitive *load_st_ops(void)
+{
+	BPF_MOD_LOAD_STRUCT_OPS(scmap_empty_cb_ext_primitive, empty_cb_ops,
+				"empty_scmap_struct_ops");
+}
+
+int main()
+{
+	BPF_MOD_CLEAR_STRUCT_OPS(scmap_empty_cb_ext_primitive,
+				 "empty_scmap_struct_ops");
+
+	struct scmap_empty_cb_ext_primitive *ext_skel = load_st_ops();
+	if (ext_skel == NULL) {
+		return 1;
+	}
+	scmap_empty_cb_ext_primitive__destroy(ext_skel);
+
+	BPF_XDP_SKEL_LOADER(scmap_empty_cb_base, XDP_IF, xdp_main,
+			    XDP_FLAGS_DRV_MODE)
+}

--- a/src/c/cmaps/scmap_empty_cb_user.c
+++ b/src/c/cmaps/scmap_empty_cb_user.c
@@ -1,0 +1,26 @@
+#include "../common.h"
+#include "../bpf_skel/scmap_empty_cb_base.skel.h"
+#include "../bpf_skel/scmap_empty_cb_ext.skel.h"
+#include "../test_helpers.h"
+
+#define XDP_IF "ens2f0"
+
+struct scmap_empty_cb_ext *load_st_ops(void)
+{
+	BPF_MOD_LOAD_STRUCT_OPS(scmap_empty_cb_ext, empty_cb_ops,
+				"empty_scmap_struct_ops");
+}
+
+int main()
+{
+	BPF_MOD_CLEAR_STRUCT_OPS(scmap_empty_cb_ext, "empty_scmap_struct_ops");
+
+	struct scmap_empty_cb_ext *ext_skel = load_st_ops();
+	if (ext_skel == NULL) {
+		return 1;
+	}
+	scmap_empty_cb_ext__destroy(ext_skel);
+
+	BPF_XDP_SKEL_LOADER(scmap_empty_cb_base, XDP_IF, xdp_main,
+			    XDP_FLAGS_DRV_MODE)
+}

--- a/src/c/cmaps/scmap_empty_lookup_user.c
+++ b/src/c/cmaps/scmap_empty_lookup_user.c
@@ -1,0 +1,10 @@
+#include "../common.h"
+#include "../bpf_skel/scmap_empty_lookup.skel.h"
+
+#define IF_NAME "ens4np0"
+
+int main()
+{
+	BPF_XDP_SKEL_LOADER(scmap_empty_lookup, IF_NAME, xdp_main,
+			    XDP_FLAGS_DRV_MODE)
+}

--- a/src/c/cmaps/scmap_empty_update_user.c
+++ b/src/c/cmaps/scmap_empty_update_user.c
@@ -1,0 +1,10 @@
+#include "../common.h"
+#include "../bpf_skel/scmap_empty_update.skel.h"
+
+#define IF_NAME "ens4np0"
+
+int main()
+{
+	BPF_XDP_SKEL_LOADER(scmap_empty_update, IF_NAME, xdp_main,
+			    XDP_FLAGS_DRV_MODE)
+}


### PR DESCRIPTION
- **add empty lookup/update eBPF programs to measure overhead**
- **add empty scmap with callback/module STRUCT_OPS implementation**
- **add `empty_primitive` kernel module**
- **add option `USE_CALLBACK_PARAM_COUNT` to control callback parameter count**
- **add `USE_CALLBACK_WORKAROUND` option to apply workaround to slow callbacks**
- **add support for `USE_CALLBACK_PARAM_COUNT == 0`**
- **(temporarily) work around kernel panics**
- **add eBPF & userspace programs for overhead experiments**
- **fix STRUCT_OPS programs not allowed to call `empty_primitive()`**
